### PR TITLE
Fix word ordering in CSV (and HTML) output

### DIFF
--- a/lib/git_pissed/formats/csv.rb
+++ b/lib/git_pissed/formats/csv.rb
@@ -9,7 +9,7 @@ module GitPissed
     end
 
     def table
-      [["date", *options.words].join(',')].tap do |table|
+      [["date", *words_by_date[0][1].keys].join(',')].tap do |table|
         words_by_date.each do |date, words|
           table << [date, *words.values].join(',')
         end


### PR DESCRIPTION
The problem is that the `options` word order may not correspond to the `words_by_date` word order. So for safety, we extract the words directly from `words_by_date` rather than relying on the `options` values.
