### PR TITLE
Little typo fix

### DIFF
--- a/lib/git_pissed/formats/templates/index.html
+++ b/lib/git_pissed/formats/templates/index.html
@@ -11,7 +11,7 @@
       }
       html,body {
         font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
-        height 100%;
+        height: 100%;
       }
       a {
         color: #000;


### PR DESCRIPTION
Github automatically add a `;` after `:`. This time, it's good ;)
